### PR TITLE
FIX #8: serial context, MBusFrameData and ctypes

### DIFF
--- a/mbus/MBusDataFixed.py
+++ b/mbus/MBusDataFixed.py
@@ -1,0 +1,13 @@
+from ctypes import Structure,c_uint8
+
+class MBusDataFixed(Structure):
+    _fields_ = [("id_bcd",    c_uint8 * 4),
+                ("tx_cnt",    c_uint8),
+                ("status",    c_uint8),
+                ("cnt1_type", c_uint8),
+                ("cnt2_type", c_uint8),
+                ("cnt1_val",  c_uint8 * 4),
+                ("cnt2_val",  c_uint8 * 4)]
+
+    def __str__(self):
+        return "MBusDataFixed: XXX"

--- a/mbus/MBusDataVariable.py
+++ b/mbus/MBusDataVariable.py
@@ -1,0 +1,17 @@
+from ctypes import Structure,c_uint8,c_void_p,c_size_t,c_char_p
+
+from mbus.MBusDataVariableHeader import MBusDataVariableHeader
+
+class MBusDataVariable(Structure):
+    _fields_ = [("header", MBusDataVariableHeader),
+                ("record", c_void_p),
+                ("nrecords", c_size_t),
+                ("data", c_char_p),
+                ("data_len", c_size_t),
+                ("more_records_follow", c_uint8),
+                ("mdh", c_uint8),
+                ("mfg_data", c_char_p),
+                ("mfg_data_len", c_size_t)]
+
+    def __str__(self):
+        return "MBusDataVariable: XXX"

--- a/mbus/MBusDataVariableHeader.py
+++ b/mbus/MBusDataVariableHeader.py
@@ -1,0 +1,13 @@
+from ctypes import Structure,c_uint8
+
+class MBusDataVariableHeader(Structure):
+    _fields_ = [("id_bcd",       c_uint8 * 4),
+                ("manufacturer", c_uint8 * 2),
+                ("version",      c_uint8),
+                ("medium",       c_uint8),
+                ("access_no",    c_uint8),
+                ("status",       c_uint8),
+                ("signature",    c_uint8 * 2)]
+
+    def __str__(self):
+        return "MBusDataVariableHeader: XXX"

--- a/mbus/MBusFrame.py
+++ b/mbus/MBusFrame.py
@@ -1,3 +1,5 @@
+from ctypes import Structure,c_uint8,c_uint32,c_void_p
+
 class MBusFrame(Structure):
     _fields_ = [("start1",   c_uint8 * 16),  # MBusFrameFixed
                 ("length1",  c_uint8),
@@ -12,7 +14,7 @@ class MBusFrame(Structure):
                 ("data_size", c_uint32),  # check
                 ("stop",      c_uint8),
                 ("timestamp", c_uint32),  # check
-                ("next",      c_uint8)]  # pointer
+                ("next",      c_void_p)]  # pointer
 
     def __str__(self):
         return "MBusFrame: XXX"

--- a/mbus/MBusFrameData.py
+++ b/mbus/MBusFrameData.py
@@ -1,6 +1,11 @@
+from ctypes import Structure,c_uint8,c_uint32
+
+from mbus.MBusDataVariable import MBusDataVariable
+from mbus.MBusDataFixed import MBusDataFixed
+
 class MBusFrameData(Structure):
-    _fields_ = [("data_var",   c_uint8 * 16),  # MBusFrameFixed
-                ("data_fixed", c_uint8),
+    _fields_ = [("data_var",   MBusDataVariable),
+                ("data_fixed", MBusDataFixed),
                 ("type",       c_uint32),
                 ("error",      c_uint32)]
 


### PR DESCRIPTION
FIX following items for issue #8 
* serial context is missing
* used modules were not always imported
* recv_frame() handle check typo
* ctype corrections
* MBusFrameData and MBusFrame fixes
* missing MBusDataVariable, MBusDataFixed, MBusDataVariableHeader added
