### PR TITLE
Autodetect location of shared library

### DIFF
--- a/mbus/MBus.py
+++ b/mbus/MBus.py
@@ -26,7 +26,7 @@ class MBus:
         """
 
         import os
-        from ctypes import cdll
+        from ctypes import cdll, util
 
         # check all given arguments for validity
         validargs = ('device','host','libpath','port')
@@ -60,7 +60,7 @@ class MBus:
                 raise TypeError("port number not given as integer")
 
         if None == libpath:
-            libpath = "/usr/local/lib/libmbus.so"
+            libpath = util.find_library('mbus')
 
         self._libmbus = cdll.LoadLibrary(libpath)
 

--- a/tests/test_MBus_connect.py
+++ b/tests/test_MBus_connect.py
@@ -6,7 +6,7 @@ from mbus import MBus
 
 @pytest.fixture
 def mbus_tcp():
-    return MBus.MBus(libpath="/usr/local/lib/libmbus.so", host="127.0.0.1")
+    return MBus.MBus(host="127.0.0.1")
 
 
 def test_connect(mbus_tcp):

--- a/tests/test_MBus_disconnect.py
+++ b/tests/test_MBus_disconnect.py
@@ -6,7 +6,7 @@ from mbus import MBus
 
 @pytest.fixture
 def mbus_tcp_connected():
-    tmp = MBus.MBus(libpath="/usr/local/lib/libmbus.so", host="127.0.0.1")
+    tmp = MBus.MBus(host="127.0.0.1")
     return tmp.connect()
 
 


### PR DESCRIPTION
Presently, if the user does not specify the library path, it is assumed to be in `/usr/local/lib`, which is wrong unless you install from source.

I don't think it right that we should have to know where to find this library, so instead, use `find_library` in `ctypes.util` to locate it automatically.