### PR TITLE
Add select_secondary_address()

### DIFF
--- a/mbus/MBus.py
+++ b/mbus/MBus.py
@@ -12,6 +12,8 @@ class MBus:
     A class to communicate to a device via MBus.
     """
 
+    MBUS_ADDRESS_NETWORK_LAYER = 0xFD
+
     _libmbus = None
 
     def __init__(self, *args, **kwargs):
@@ -113,6 +115,17 @@ class MBus:
             if self._libmbus.mbus_send_request_frame(
                     self.handle, c_int(address)) == -1:
                 raise Exception("libmbus.mbus_send_request_frame failed")
+        else:
+            raise Exception("Handle object not configure")
+
+    def select_secondary_address(self, address):
+        """
+        Low-level function: select secondary address
+        """
+        if self.handle:
+            if self._libmbus.mbus_select_secondary_address(
+                    self.handle, c_char_p(str.encode(str(address)))) == -1:
+                raise Exception("libmbus.mbus_select_secondary_address failed")
         else:
             raise Exception("Handle object not configure")
 


### PR DESCRIPTION
Add one more method to read sensors using secondary address. This is how it works:

``` python
…
# mbus_is_secondary_address
mbus.select_secondary_address(1401980977041407)
mbus.send_request_frame(MBus.MBUS_ADDRESS_NETWORK_LAYER)
reply = mbus.recv_frame()
…
```

This code is based on mbus-protocol.c from libmbus
