### PR TITLE
Fix MBusDataFixedMedium duplicate enum key

### DIFF
--- a/mbus/MBusDataFixed.py
+++ b/mbus/MBusDataFixed.py
@@ -22,7 +22,7 @@ class MBusDataFixedMedium(Enum):
     HotWaterMode2 = 0x0C
     WaterMode2 = 0x0D
     HCAMode2 = 0x0E
-    Reserved = 0x0F
+    Reserved2 = 0x0F
 
 
 class MBusDataFixedUnit(Enum):


### PR DESCRIPTION
Python2 did not complain about this but Python3 is more strict here

```
Traceback (most recent call last):
  File "./test.py", line 3, in <module>
    from mbus.MBus import MBus
  File "/home/cougar/git/python-mbus/mbus/MBus.py", line 6, in <module>
    from .MBusFrameData import MBusFrameData
  File "/home/cougar/git/python-mbus/mbus/MBusFrameData.py", line 5, in <module>
    from mbus.MBusDataFixed import MBusDataFixed
  File "/home/cougar/git/python-mbus/mbus/MBusDataFixed.py", line 4, in <module>
    class MBusDataFixedMedium(Enum):
  File "/home/cougar/git/python-mbus/mbus/MBusDataFixed.py", line 25, in MBusDataFixedMedium
    Reserved = 0x0F
  File "/usr/lib64/python3.4/enum.py", line 66, in __setitem__
    raise TypeError('Attempted to reuse key: %r' % key)
TypeError: Attempted to reuse key: 'Reserved'
```
