### PR TITLE
Fix 8e0ef2b: select_secondary_address is already in MBusLowLevel

### DIFF
--- a/mbus/MBus.py
+++ b/mbus/MBus.py
@@ -115,9 +115,9 @@ class MBus:
         Low-level function: select secondary address
         """
         if self.handle:
-            if self._libmbus.mbus_select_secondary_address(
-                    self.handle, c_char_p(str.encode(str(address)))) == -1:
-                raise Exception("libmbus.mbus_select_secondary_address failed")
+            if self._libmbus.select_secondary_address(
+                    self.handle, str(address).encode('utf8')) == -1:
+                raise Exception("libmbus.select_secondary_address failed")
         else:
             raise Exception("Handle object not configure")
 


### PR DESCRIPTION
Found that my last commit 8e0ef2b was also based on too old version. Now all `libmbus` functions are defined in `MBusLowLevel` and are used via that class. I fixed that and also removed `MBUS_ADDRESS_NETWORK_LAYER` constant from `MBus.py` It is also defined in `MBusLowLevel`.

The working test code looks like this now:

``` python
from mbus.MBus import MBus
from mbus.MBusLowLevel import MBUS_ADDRESS_NETWORK_LAYER
mbus = MBus(device="/dev/ttyUSB0")
mbus.connect()

# mbus_is_secondary_address
mbus.select_secondary_address(1401980977041407)
mbus.send_request_frame(MBUS_ADDRESS_NETWORK_LAYER)
reply = mbus.recv_frame()
reply_data = mbus.frame_data_parse(reply)
xml_buff = mbus.frame_data_xml(reply_data)
print(xml_buff)
```

Tested with latest version using python2 and python3 (with all py3 fixes applied)
