### PR TITLE
Bugfix: memory leaks are prevented

### DIFF
--- a/examples/mbus-test-1.py
+++ b/examples/mbus-test-1.py
@@ -38,3 +38,7 @@ if debug:
 xml_buff = mbus.frame_data_xml(reply_data)
 
 print("xml_buff =", xml_buff)
+
+mbus.frame_data_free(reply_data)
+
+mbus.disconnect()

--- a/mbus/MBusLowLevel.py
+++ b/mbus/MBusLowLevel.py
@@ -406,7 +406,7 @@ class MBusLib(object):
         self.frame_verify                   = lib.mbus_frame_verify
         self.frame_verify.argtypes          = [mbus_frame_p]
         self.frame_verify.restype           = c_int
-    
+
         self.frame_internal_pack            = lib.mbus_frame_internal_pack
         self.frame_internal_pack.argtypes   = [mbus_frame_p, mbus_frame_data_p]
         self.frame_internal_pack.restype    = c_int
@@ -465,7 +465,7 @@ class MBusLib(object):
 
         self.frame_data_xml                 = lib.mbus_frame_data_xml
         self.frame_data_xml.argtypes        = [mbus_frame_data_p]
-        self.frame_data_xml.restype         = c_char_p
+        self.frame_data_xml.restype         = c_void_p
 
         self.data_variable_header_xml       = lib.mbus_data_variable_header_xml
         self.data_variable_header_xml.argtypes  = [mbus_data_variable_header_p]


### PR DESCRIPTION
As part of the development of a long-running service based on python-mbus, we realized that the library was leaking. This was traced to three issues:
* the MBus context was not freed after deletion
* the frame data was not freed and frame_data_free was not exposed
* the frame_data_xml did not free the returned buffer

This pull request addresses all three issues and corrects the example accordingly.
If you have any comment or remark, we'll be happy to address those as part of this PR.
Thank you.