### PR TITLE
Fix MBusFrame type field name

### DIFF
--- a/mbus/MBusFrame.py
+++ b/mbus/MBusFrame.py
@@ -1,4 +1,4 @@
-from ctypes import Structure, c_uint8, c_long, c_size_t, POINTER
+from ctypes import Structure, c_uint8, c_int, c_long, c_size_t, POINTER
 
 c_time_t = c_long
 
@@ -18,7 +18,7 @@ MBusFrame._fields_ = [
         ("stop",     c_uint8),
         ("data",     c_uint8 * 252),
         ("data_size", c_size_t),
-        ("stop",      c_uint8),
+        ("type",      c_int),
         ("timestamp", c_time_t),
         ("next",      POINTER(MBusFrame))
 ]


### PR DESCRIPTION
This is fix for typo in mbus/MBusFrame.py where "stop" field was added twice