### PR TITLE
Fix mbus_frame_calc_checksum() return type

### DIFF
--- a/mbus/MBusLowLevel.py
+++ b/mbus/MBusLowLevel.py
@@ -375,7 +375,7 @@ class MBusLib(object):
 
         self.frame_calc_checksum            = lib.mbus_frame_calc_checksum
         self.frame_calc_checksum.argtypes   = [mbus_frame_p]
-        self.frame_calc_checksum.restypes   = c_int
+        self.frame_calc_checksum.restypes   = c_ubyte
 
         self.frame_calc_length              = lib.mbus_frame_calc_length
         self.frame_calc_length.argtypes     = [mbus_frame_p]


### PR DESCRIPTION
Another fix for `mbus_frame_calc_checksum()` return type